### PR TITLE
Add HAL pins for stepgen maxvel

### DIFF
--- a/LinuxCNC/Components/Remora-eth/remora-eth-3.0.c
+++ b/LinuxCNC/Components/Remora-eth/remora-eth-3.0.c
@@ -331,6 +331,11 @@ This is throwing errors from axis.py for some reason...
 		        comp_id, "%s.joint.%01d.maxaccel", prefix, n);
 		if (retval < 0) goto error;
 		data->maxaccel[n] = 1.0;
+
+      retval = hal_param_float_newf(HAL_RW, &(data->maxvel[n]),
+		        comp_id, "%s.joint.%01d.maxvel", prefix, n);
+		if (retval < 0) goto error;
+		data->maxvel[n] = 0;
 	}
 
 	for (n = 0; n < VARIABLES; n++) {

--- a/LinuxCNC/Components/Remora-spi/remora-spi.c
+++ b/LinuxCNC/Components/Remora-spi/remora-spi.c
@@ -389,6 +389,11 @@ This is throwing errors from axis.py for some reason...
 		        comp_id, "%s.joint.%01d.maxaccel", prefix, n);
 		if (retval < 0) goto error;
 		data->maxaccel[n] = 1.0;
+
+      retval = hal_param_float_newf(HAL_RW, &(data->maxvel[n]),
+		        comp_id, "%s.joint.%01d.maxvel", prefix, n);
+		if (retval < 0) goto error;
+		data->maxvel[n] = 0;
 	}
 
 	for (n = 0; n < VARIABLES; n++) {


### PR DESCRIPTION
This PR adds HAL pins to configure stepgen max accel and defaults to 0 rather than 1 to ensure we don't break the calculation that happens later in the stepgen if unconfigured. This is likely only useful if driving the stepgen with something other than a typical joint, such as the Carousel component when setting up an ATC carousel. 