### PR TITLE
added error output for rt_rp1lib_init and rp1spi_init, now return zer…

### DIFF
--- a/LinuxCNC/Components/Remora-spi/remora-spi.c
+++ b/LinuxCNC/Components/Remora-spi/remora-spi.c
@@ -783,14 +783,20 @@ int rt_rp1lib_init(void)
 
     inst = rp1_create_instance(chip, phys_addr, NULL);
     if (!inst)
-        return -1;
+    {
+        rtapi_print_msg(RTAPI_MSG_ERR,"rp1_create_instance failed.\n");
+        return 0;
+    }
 
     inst->phys_addr = phys_addr;
 
     // map memory
     inst->mem_fd = rtapi_open_as_root("/dev/mem", O_RDWR | O_SYNC);
     if (inst->mem_fd < 0)
-        return errno;
+    {
+        rtapi_print_msg(RTAPI_MSG_ERR,"rtapi_open_as_root failed, errno = %d\n", errno);
+        return 0;
+    }
 
     inst->priv = mmap(
         NULL,
@@ -804,7 +810,10 @@ int rt_rp1lib_init(void)
     DEBUG_PRINT("Base address: %11lx, size: %lx, mapped at address: %p\n", inst->phys_addr, RP1_BAR1_LEN, inst->priv);
 
     if (inst->priv == MAP_FAILED)
-        return errno;
+    {
+        rtapi_print_msg(RTAPI_MSG_ERR,"mmap failed, errno = %d\n", errno);
+        return 0;
+    }
 
     return 1;
 }

--- a/LinuxCNC/Components/Remora-spi/rp1lib.c
+++ b/LinuxCNC/Components/Remora-spi/rp1lib.c
@@ -124,8 +124,8 @@ int rp1spi_init(uint8_t spi_num, uint8_t cs_num, uint8_t mode, uint32_t freq)
     if (res.gpio_num != -1) {
         DEBUG_PRINT("Pin: MOSI -> GPIO Number: %d, FSEL Number: %d\n", res.gpio_num, res.fsel_num);
     } else {
-		return -1;
-        printf("Failed to get GPIO and FSEL for pin: %s\n", mosi_pin);
+        rtapi_print_msg(RTAPI_MSG_ERR, "Failed to get GPIO and FSEL for pin: %s\n", mosi_pin);
+        return 0;
     }
     gpio_set_fsel(res.gpio_num, res.fsel_num);
     gpio_set_pull(res.gpio_num, PULL_NONE);
@@ -135,8 +135,8 @@ int rp1spi_init(uint8_t spi_num, uint8_t cs_num, uint8_t mode, uint32_t freq)
     if (res.gpio_num != -1) {
         DEBUG_PRINT("Pin: MISO -> GPIO Number: %d, FSEL Number: %d\n", res.gpio_num, res.fsel_num);
     } else {
-		return -1;
-        printf("Failed to get GPIO and FSEL for pin: %s\n", miso_pin);
+        rtapi_print_msg(RTAPI_MSG_ERR, "Failed to get GPIO and FSEL for pin: %s\n", miso_pin);
+        return 0;
     }
     gpio_set_fsel(res.gpio_num, res.fsel_num);
     gpio_set_pull(res.gpio_num, PULL_NONE);
@@ -146,8 +146,8 @@ int rp1spi_init(uint8_t spi_num, uint8_t cs_num, uint8_t mode, uint32_t freq)
     if (res.gpio_num != -1) {
         DEBUG_PRINT("Pin: SCLK -> GPIO Number: %d, FSEL Number: %d\n", res.gpio_num, res.fsel_num);
     } else {
-		return -1;
-        printf("Failed to get GPIO and FSEL for pin: %s\n", sclk_pin);
+        rtapi_print_msg(RTAPI_MSG_ERR, "Failed to get GPIO and FSEL for pin: %s\n", sclk_pin);
+        return 0;
     }
     gpio_set_fsel(res.gpio_num, res.fsel_num);
     gpio_set_pull(res.gpio_num, PULL_NONE);
@@ -157,8 +157,8 @@ int rp1spi_init(uint8_t spi_num, uint8_t cs_num, uint8_t mode, uint32_t freq)
     if (res.gpio_num != -1) {
         DEBUG_PRINT("Pin: CS   -> GPIO Number: %d, FSEL Number: %d\n", res.gpio_num, res.fsel_num);
     } else {
-		return -1;
-        printf("Failed to get GPIO and FSEL for pin: %s\n", cs_pin);
+        rtapi_print_msg(RTAPI_MSG_ERR, "Failed to get GPIO and FSEL for pin: %s\n", cs_pin);
+        return 0;
     }
     gpio_set_fsel(res.gpio_num, res.fsel_num);
     gpio_set_pull(res.gpio_num, PULL_NONE);


### PR DESCRIPTION
…o on failure instead of -1 (calling code interprets return value as boolean, which caused silent failures)